### PR TITLE
Add MainUI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It is utilising a NodeJS application and the popular [NGINX](https://www.nginx.c
 - [Introduction](#introduction)
 - [Access to Sitemaps](#access-to-sitemaps)
 - [Access to Items](#access-to-items)
+- [Access to MainUI pages](#access-to-mainui-pages)
 - [NodeJS package](#nodejs-package)
   - [Installation](#installation)
   - [Configuration options](#configuration-options)
@@ -50,6 +51,11 @@ Only the following Item operations are allowed:
 - Get a single Item.
 - Get the state of an Item.
 - Send a command to an Item.
+
+## Access to MainUI pages
+
+A client can access all MainUI pages whose name matches the rules for Sitemaps (refer to [Access to Sitemaps](#access-to-sitemaps)).
+The client has to directly request a page since general MainUI access is now allowed.
 
 ## NodeJS package
 

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -28,7 +28,7 @@ NGINX parses some information of the client certificates to get the user and org
 The user is parsed from the *Common Name* (abbrev. *CN*).
 
 Orgs are parsed from the *Organizational Unit* (abbrev. *OU*).
-Orgs have to be comma seperated.
+Orgs have to be point ``.`` seperated.
 
 Spaces and hyphens in those are replaced with underscores before a request to the openHAB server is made.
 It is recommended to **NOT USE spaces and hyphens** to avoid problems.

--- a/nginx/openhab-multiuser.conf
+++ b/nginx/openhab-multiuser.conf
@@ -208,6 +208,10 @@ server {
 
   # Dynamic resources, reponse depends on client.
 
+    # Prevent errors on auth endpoints when $pageid is null.
+    location = /page/ {
+      return 404;
+    }
     # Provides: GET /page/{pageid} Gets MainUI pages.
     # From: openHAB server
     # Uses: auth_request, $pageid must be an allowed Sitemap for client
@@ -218,6 +222,10 @@ server {
         proxy_pass                            http://localhost:8080/page/;
         auth_request                          /auth/sitemaps;
         include                               /etc/nginx/proxy-headers.conf;
+    }
+    # Prevent errors on auth endpoints when $itemname is null.
+    location = /rest/persistence/items/ {
+      return 404;
     }
     # Provides: GET /rest/persistence/items/{itemname} Gets Item persistence data from the persistence service.
     # From: openHAB server

--- a/nginx/openhab-multiuser.conf
+++ b/nginx/openhab-multiuser.conf
@@ -59,20 +59,20 @@ server {
 
     # Operation: Icon access.
     # From: openHAB server
-    location /icon {
+    location /icon/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass                            http://localhost:8080/icon;
+        proxy_pass                            http://localhost:8080/icon/;
         include                               /etc/nginx/proxy-headers.conf;
     }
     # Operation: Image access.
     # From: openHAB server
-    location /images {
+    location /images/ {
         limit_except GET {                    
           deny all;
         }
-        proxy_pass                            http://localhost:8080/images;
+        proxy_pass                            http://localhost:8080/images/;
         include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides:
@@ -144,28 +144,28 @@ server {
 
     # Provides: MainUI app.
     # From: openHAB server
-    location /css {
+    location /css/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/css;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/css/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
-    location /js {
+    location /js/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/js;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/js/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides: Icons & images for MainUI.
     # From: openHAB server
-    location /res {
+    location /res/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/res;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/res/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides: UI configuration & resource list.
     # From: openHAB server
@@ -173,8 +173,8 @@ server {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/manifest.json;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/manifest.json;
+        include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides: UI components for the MainUI.
     #   - GET /rest/ui/components/{namespace} Get all registered UI components in the specified namespace.
@@ -184,56 +184,72 @@ server {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/rest/ui/components/;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/rest/ui/components/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides: Fonts for the MainUI.
     # From: openHAB server
-    location /fonts {
+    location /fonts/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/fonts;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/fonts/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
     # Provides: Static content from the $openhab_conf/html folder.
     # From: openHAB server
-    location /static {
+    location /static/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/static;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/static/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
 
   # Dynamic resources, reponse depends on client.
 
-    # for /page: Limit access
-    location /page {
+    # Provides: GET /page/{pageid} Gets MainUI pages.
+    # From: openHAB server
+    # Uses: auth_request, $pageid must be an allowed Sitemap for client
+    location /page/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/page;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/page/;
+        auth_request                          /auth/sitemaps;
+        include                               /etc/nginx/proxy-headers.conf;
     }
-    # for /rest/persistence/items: Limit access
+    # Provides: GET /rest/persistence/items/{itemname} Gets Item persistence data from the persistence service.
+    # From: openHAB server
+    # Uses: auth_request
     location /rest/persistence/items/ {
         limit_except GET {
           deny all;
         }
-        proxy_pass http://localhost:8080/rest/persistence/items/;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/rest/persistence/items/;
+        auth_request                          /auth/items;
+        include                               /etc/nginx/proxy-headers.conf;
     }
-    # No possibility to limit
-    location /rest/events {
+    # Provides: SSE event listeners.
+    #   - GET /rest/events Get all events.
+    #   - GET /rest/events/states Initiates a new Item state tracker connection.
+    #   - POST /rest/events/states/{connectionId} Changes the list of Items a SSE connection will receive state updates to.
+    # From: openHAB server
+    # Note: This might be a potential weakness where an attacker can register a listener for Items he has no access to.
+    location /rest/events/ {
         limit_except GET POST {
           deny all;
         }
-        proxy_pass http://localhost:8080/rest/events;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass                            http://localhost:8080/rest/events/;
+        include                               /etc/nginx/proxy-headers.conf;
     }
 
 # Authorization endpoints.
+    # Provides authorization for $sitemapname:
+    #   - */sitemaps/{sitemapname}
+    #   - */sitemaps/{sitemapname}/*
+    #   - */page/{sitemapname}
+    # By using regex: /\/(sitemaps|page)\/([a-zA-Z_0-9]+)/
     location = /auth/sitemaps {
         internal;
         proxy_pass                            http://localhost:8081/auth/sitemaps;
@@ -243,7 +259,10 @@ server {
         proxy_set_header X-OPENHAB-USER       $ssl_client_s_dn_cn;
         proxy_set_header X-OPENHAB-ORG        $ssl_client_s_dn_ou;
     }
-
+    # Provides authorization for $itemname:
+    #   - */items/{itemname}
+    #   - */sitemaps/{itemname}/*
+    # By using regex: /\/items\/([a-zA-Z_0-9]+)/
     location = /auth/items {
         internal;
         proxy_pass                            http://localhost:8081/auth/items;

--- a/nginx/openhab-multiuser.conf
+++ b/nginx/openhab-multiuser.conf
@@ -54,6 +54,9 @@ server {
     # openHAB 3 api authentication
     add_header Set-Cookie                     X-OPENHAB-AUTH-HEADER=1;
 
+# The following routes are required for the openHAB app.
+  # Static resources.
+
     # Operation: Icon access.
     # From: openHAB server
     location /icon {
@@ -72,7 +75,7 @@ server {
         proxy_pass                            http://localhost:8080/images;
         include                               /etc/nginx/proxy-headers.conf;
     }
-    # Operations:
+    # Provides:
     #   - GET /rest/? openHAB Server & API information
     # From: openHAB Server
     location = /rest/ {
@@ -82,7 +85,10 @@ server {
         proxy_pass                            http://localhost:8080/rest/;
         include                               /etc/nginx/proxy-headers.conf;
     }
-    # Operations:
+
+  # Dynamic resources, reponse depends on client.
+
+    # Provides:
     #   - GET /rest/sitemaps/events/{subscriptionid} Get Sitemap events.
     #   - POST /rest/sitemaps/events/subscribe Creates a Sitemap event subscription.
     # From: openHAB Server
@@ -93,8 +99,8 @@ server {
         proxy_pass                            http://localhost:8080/rest/sitemaps/events/;
         include                               /etc/nginx/proxy-headers.conf;
     }
-    # Operations:
-    #   - GET /rest/sitemaps Get all available Sitemaps.
+    # Provides:
+    #   - GET /rest/sitemaps Get all available Sitemaps for client.
     # From: NodeJS app
     location = /rest/sitemaps/ { # Note: The slash at the end is required!! Otherwise client can see all Sitemaps.
         limit_except GET {
@@ -105,7 +111,7 @@ server {
         proxy_set_header X-OPENHAB-USER       $ssl_client_s_dn_cn;
         proxy_set_header X-OPENHAB-ORG        $ssl_client_s_dn_ou;
     }
-    # Operations:
+    # Provides:
     #   - GET /rest/sitemaps/{sitemapname} Get Sitemap by name.
     #   - GET /rest/sitemaps/{sitemapname}/{pageid} Polls the data for a Sitemap.
     # From: openHAB Server
@@ -118,7 +124,7 @@ server {
         auth_request                          /auth/sitemaps;
         include                               /etc/nginx/proxy-headers.conf;
     }
-    # Operations (only limited by methods GET & POST):
+    # Provides (only limited by methods GET & POST):
     #   - GET /rest/items/{itemname} Gets a single Item.
     #   - POST /rest/items/{itemname} Sends a command to an Item.
     #   - GET /rest/items/{itemname}/state Gets the state of an Item.
@@ -132,7 +138,102 @@ server {
         auth_request                          /auth/items;
         include                               /etc/nginx/proxy-headers.conf;
       }
-    
+
+# Additionally required for the MainUI.
+  # Static resources.
+
+    # Provides: MainUI app.
+    # From: openHAB server
+    location /css {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/css;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    location /js {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/js;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # Provides: Icons & images for MainUI.
+    # From: openHAB server
+    location /res {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/res;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # Provides: UI configuration & resource list.
+    # From: openHAB server
+    location = /manifest.json {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/manifest.json;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # Provides: UI components for the MainUI.
+    #   - GET /rest/ui/components/{namespace} Get all registered UI components in the specified namespace.
+    #   - GET /rest/ui/components/{namespace}/{componentUID} Get a specific UI component in the specified namespace.
+    # From: openHAB server
+    location /rest/ui/components/ {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/rest/ui/components/;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # Provides: Fonts for the MainUI.
+    # From: openHAB server
+    location /fonts {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/fonts;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # Provides: Static content from the $openhab_conf/html folder.
+    # From: openHAB server
+    location /static {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/static;
+        include /etc/nginx/proxy-headers.conf;
+    }
+
+  # Dynamic resources, reponse depends on client.
+
+    # for /page: Limit access
+    location /page {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/page;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # for /rest/persistence/items: Limit access
+    location /rest/persistence/items/ {
+        limit_except GET {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/rest/persistence/items/;
+        include /etc/nginx/proxy-headers.conf;
+    }
+    # No possibility to limit
+    location /rest/events {
+        limit_except GET POST {
+          deny all;
+        }
+        proxy_pass http://localhost:8080/rest/events;
+        include /etc/nginx/proxy-headers.conf;
+    }
+
+# Authorization endpoints.
     location = /auth/sitemaps {
         internal;
         proxy_pass                            http://localhost:8081/auth/sitemaps;

--- a/nginx/openhab-multiuser.conf
+++ b/nginx/openhab-multiuser.conf
@@ -54,6 +54,11 @@ server {
     # openHAB 3 api authentication
     add_header Set-Cookie                     X-OPENHAB-AUTH-HEADER=1;
 
+# Root location
+    location = / {
+        return 404;
+    }
+
 # The following routes are required for the openHAB app.
   # Static resources.
 
@@ -277,6 +282,15 @@ server {
         proxy_pass_request_body               off;
         proxy_set_header                      Content-Length "";
         proxy_set_header                      X-Original-URI $request_uri;
+        proxy_set_header X-OPENHAB-USER       $ssl_client_s_dn_cn;
+        proxy_set_header X-OPENHAB-ORG        $ssl_client_s_dn_ou;
+    }
+    # Provides authorization whether client has admin privileges.
+    location = /auth/admin {
+        internal;
+        proxy_pass                            http://192.168.178.20:8080/auth/admin;
+        proxy_pass_request_body               off;
+        proxy_set_header                      Content-Length "";
         proxy_set_header X-OPENHAB-USER       $ssl_client_s_dn_cn;
         proxy_set_header X-OPENHAB-ORG        $ssl_client_s_dn_ou;
     }

--- a/nodejs/src/components/items/routes.js
+++ b/nodejs/src/components/items/routes.js
@@ -51,7 +51,8 @@ const items = (app) => {
   app.get('/auth/items', requireHeader('X-OPENHAB-USER'), requireHeader('X-ORIGINAL-URI'), async (req, res) => {
     const org = req.headers['x-openhab-org'] || [];
     const user = req.headers['x-openhab-user'];
-    const itemname = req.headers['x-original-uri'].split('/')[3];
+    const regex = /\/items\/([a-zA-Z_0-9]+)/;
+    const itemname = regex.exec(req.headers['x-original-uri'])[1];
 
     try {
       const allowed = await itemAllowedForClient(backendInfo.HOST, req, user, org, itemname);

--- a/nodejs/src/components/items/security.js
+++ b/nodejs/src/components/items/security.js
@@ -30,6 +30,7 @@ const getItemsForUser = async function (HOST, expressReq, user, org) {
 
 /**
  * Check whether Item access is allowed for client.
+ * Must be used with await in async functions.
  *
  * @memberof itemsSecurity
  * @param {String} HOST hostname of openHAB server
@@ -40,8 +41,13 @@ const getItemsForUser = async function (HOST, expressReq, user, org) {
  * @returns {Boolean} whether Item access is allowed or not
  */
 export const itemAllowedForClient = async function (HOST, expressReq, user, org, itemname) {
-  const items = await getItemsForUser(HOST, expressReq, user, org);
-  const allowed = items.includes(itemname);
-  logger.info({ user: user, orgs: org }, `itemAllowedForUser(): Item ${itemname} allowed: ${allowed}`);
-  return allowed;
+  try {
+    const items = await getItemsForUser(HOST, expressReq, user, org);
+    const allowed = items.includes(itemname);
+    logger.info({ user: user, orgs: org }, `itemAllowedForUser(): Item ${itemname} allowed: ${allowed} (typeof ${typeof allowed})`);
+    return allowed;
+  } catch (err) {
+    logger.error(err);
+    return false;
+  }
 };

--- a/nodejs/src/components/items/security.js
+++ b/nodejs/src/components/items/security.js
@@ -15,7 +15,7 @@ import { getAllSitemapsFiltered, getItemsOfSitemap } from '../sitemaps/backend.j
  * @param {String} HOST hostname of openHAB server
  * @param {*} expressReq request object from expressjs
  * @param {String} user username
- * @param {Array<String>} org array of organizations the user is member
+ * @param {String|Array<String>} org organizations the client is member of
  * @returns {Array<String>} names of Items allowed for client
  */
 const getItemsForUser = async function (HOST, expressReq, user, org) {
@@ -36,7 +36,7 @@ const getItemsForUser = async function (HOST, expressReq, user, org) {
  * @param {String} HOST hostname of openHAB server
  * @param {*} expressReq request object from expressjs
  * @param {String} user username
- * @param {Array<String>} org array of organizations the user is member
+ * @param {String|Array<String>} org organizations the client is member of
  * @param {String} itemname name of Item
  * @returns {Boolean} whether Item access is allowed or not
  */

--- a/nodejs/src/components/middleware.js
+++ b/nodejs/src/components/middleware.js
@@ -18,10 +18,6 @@ export const requireHeader = (header) => {
       res.status(400).send(`${header} is required!`);
       logger.warn(`${req.ip} did not sent the required header ${header}`);
       return;
-    } else {
-      for (const i in req.headers) {
-        req.headers[i] = req.headers[i].replace(/( )|(-)/g, '_');
-      }
     }
     next();
   };
@@ -37,6 +33,21 @@ export const replaceSpaceHyphenWithUnderscore = (headers) => {
   return function (req, res, next) {
     for (const i in headers) {
       if (req.headers[headers[i]]) req.headers[headers[i].toLowerCase()] = req.headers[headers[i].toLowerCase()].replace(/( )|(-)/g, '_');
+    }
+    next();
+  };
+};
+
+/**
+ * Formats header X-OPENHAB-ORG from String to Array<String>.
+ * Must not be applied before {@link middlewares.replaceSpaceHyphenWithUnderscore}!
+ *
+ * @memberof middlewares
+ */
+export const formatOrgs = () => {
+  return function (req, res, next) {
+    if (req.headers['x-openhab-org']) {
+      req.headers['x-openhab-org'] = req.headers['x-openhab-org'].split('.');
     }
     next();
   };

--- a/nodejs/src/components/routes.js
+++ b/nodejs/src/components/routes.js
@@ -1,5 +1,8 @@
 import sitemaps from './sitemaps/routes.js';
 import items from './items/routes.js';
+import { requireHeader } from './middleware.js';
+import { sitemapAllowedForClient } from './sitemaps/security.js';
+import { ADMIN_OU } from '../server.js';
 
 /**
  * Routes namespace. Providing routes.
@@ -40,6 +43,48 @@ export default (app) => {
         { type: 'rest-api', path: '/rest' }
       ]
     });
+  });
+
+  /**
+   * @swagger
+   * /auth/admin:
+   *   get:
+   *     summary: Authorization endpoint whether client has admin privileges.
+   *     description: Used by nginx auth_request.
+   *     parameters:
+   *       - in: header
+   *         name: X-OPENHAB-USER
+   *         required: true
+   *         description: Name of user
+   *         schema:
+   *           type: string
+   *         style: form
+   *       - in: header
+   *         name: X-OPENHAB-ORG
+   *         required: false
+   *         description: Organisations the user is member of
+   *         schema:
+   *           type: string
+   *         style: form
+   *     responses:
+   *       200:
+   *         description: Allowed
+   *       403:
+   *         description: Forbidden
+   */
+  app.get('/auth/admin', requireHeader('X-OPENHAB-USER'), async (req, res) => {
+    const user = req.headers['x-openhab-user'];
+    const org = req.headers['x-openhab-org'] || '';
+    try {
+      const allowed = await sitemapAllowedForClient(user, org, ADMIN_OU);
+      if (allowed === true) {
+        res.status(200).send();
+      } else {
+        res.status(403).send();
+      }
+    } catch {
+      res.status(500).send();
+    }
   });
 
   // Other routes

--- a/nodejs/src/components/sitemaps/backend.js
+++ b/nodejs/src/components/sitemaps/backend.js
@@ -52,7 +52,7 @@ export const getAllSitemaps = async function (HOST, expressReq) {
  * @param {String} HOST hostname of openHAB server
  * @param {*} expressReq request object from expressjs
  * @param {String} user username
- * @param {Array<String>} org array of organisations the user is member
+ * @param {String|Array<String>} org organizations the client is member of
  * @returns {Array<Object>} array of Sitemaps
  */
 export const getAllSitemapsFiltered = async function (HOST, expressReq, user, org) {

--- a/nodejs/src/components/sitemaps/routes.js
+++ b/nodejs/src/components/sitemaps/routes.js
@@ -109,7 +109,8 @@ const sitemaps = (app) => {
   app.get('/auth/sitemaps', requireHeader('X-OPENHAB-USER'), requireHeader('X-ORIGINAL-URI'), (req, res, next) => {
     const org = req.headers['x-openhab-org'] || [];
     const user = req.headers['x-openhab-user'];
-    const sitemapname = req.headers['x-original-uri'].split('/')[3];
+    const regex = /\/(sitemaps|page)\/([a-zA-Z_0-9]+)/;
+    const sitemapname = regex.exec(req.headers['x-original-uri'])[2];
     const allowed = sitemapAllowedForClient(user, org, sitemapname);
     if (allowed) {
       res.status(200).send();

--- a/nodejs/src/components/sitemaps/security.js
+++ b/nodejs/src/components/sitemaps/security.js
@@ -32,10 +32,10 @@ export const sitemapAllowedForClient = (user, org, sitemapname) => {
   const orgOfSitemap = (sitemapname.includes(ORG_SEPARATOR)) ? sitemapname.split(ORG_SEPARATOR)[0] : sitemapname;
   logger.debug(`sitemapAllowedForUser(): Organization of Sitemap ${sitemapname} is ${orgOfSitemap}`);
   if (sitemapname === user || org.includes(orgOfSitemap)) {
-    logger.info(`sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} allowed for ${user}/[${org}]`);
+    logger.info({ user: user, orgs: org }, `sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} allowed`);
     return true;
   } else {
-    logger.info(`sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} forbidden for ${user}/[${org}]`);
+    logger.info({ user: user, orgs: org }, `sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} forbidden`);
     return false;
   }
 };

--- a/nodejs/src/components/sitemaps/security.js
+++ b/nodejs/src/components/sitemaps/security.js
@@ -13,7 +13,7 @@ import { ORG_SEPARATOR } from '../../server.js';
  *
  * @memberof sitemapsSecurity
  * @param {String} user username
- * @param {String|Array<String>} org organizations the user is member
+ * @param {String|Array<String>} org organizations the client is member of
  * @param {String} sitemapname name of Sitemap
  * @returns {Boolean} whether Sitemap access is allowed or not
  */

--- a/nodejs/src/components/sitemaps/security.js
+++ b/nodejs/src/components/sitemaps/security.js
@@ -15,6 +15,7 @@ dotenv.config();
  * @memberof sitemapsSecurity
  */
 const ORG_SEPARATOR = process.env.ORG_SEPARATOR || '_org_';
+logger.debug(`Organization separator is ${ORG_SEPARATOR}`);
 
 /**
  * Check whether Sitemap access is allowed for client.
@@ -29,12 +30,12 @@ export const sitemapAllowedForClient = (user, org, sitemapname) => {
   org = new Array(org);
   // If Sitemap name includes ORG_SEPARATOR, return string before ORG_SEPARATOR, else return Sitemap name.
   const orgOfSitemap = (sitemapname.includes(ORG_SEPARATOR)) ? sitemapname.split(ORG_SEPARATOR)[0] : sitemapname;
-  logger.debug(`sitemapAllowedForUser(): Organization of Sitemapp ${sitemapname} is ${orgOfSitemap}`);
+  logger.debug(`sitemapAllowedForUser(): Organization of Sitemap ${sitemapname} is ${orgOfSitemap}`);
   if (sitemapname === user || org.includes(orgOfSitemap)) {
-    logger.info(`sitemapAllowedForUser(): Access to Sitemapp ${sitemapname} allowed for ${user}/[${org}]`);
+    logger.info(`sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} allowed for ${user}/[${org}]`);
     return true;
   } else {
-    logger.info(`sitemapAllowedForUser(): Access to Sitemapp ${sitemapname} forbidden for ${user}/[${org}]`);
+    logger.info(`sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} forbidden for ${user}/[${org}]`);
     return false;
   }
 };

--- a/nodejs/src/components/sitemaps/security.js
+++ b/nodejs/src/components/sitemaps/security.js
@@ -1,7 +1,5 @@
-import * as dotenv from 'dotenv';
 import logger from './../../logger.js';
-
-dotenv.config();
+import { ORG_SEPARATOR } from '../../server.js';
 
 /**
  * Items security namespace. Provides security checks for Item access.
@@ -10,32 +8,26 @@ dotenv.config();
  */
 
 /**
- * Separates the organization name at beginning of Sitemap name from the full name.
- *
- * @memberof sitemapsSecurity
- */
-const ORG_SEPARATOR = process.env.ORG_SEPARATOR || '_org_';
-logger.debug(`Organization separator is ${ORG_SEPARATOR}`);
-
-/**
  * Check whether Sitemap access is allowed for client.
+ * Must be used with await in async functions.
  *
  * @memberof sitemapsSecurity
  * @param {String} user username
- * @param {Array<String>} org array of organizations the user is member
+ * @param {String|Array<String>} org organizations the user is member
  * @param {String} sitemapname name of Sitemap
  * @returns {Boolean} whether Sitemap access is allowed or not
  */
 export const sitemapAllowedForClient = (user, org, sitemapname) => {
-  org = new Array(org);
+  if (typeof org === 'string') org = org.toString().split('.');
   // If Sitemap name includes ORG_SEPARATOR, return string before ORG_SEPARATOR, else return Sitemap name.
   const orgOfSitemap = (sitemapname.includes(ORG_SEPARATOR)) ? sitemapname.split(ORG_SEPARATOR)[0] : sitemapname;
   logger.debug(`sitemapAllowedForUser(): Organization of Sitemap ${sitemapname} is ${orgOfSitemap}`);
+  let allowed;
   if (sitemapname === user || org.includes(orgOfSitemap)) {
-    logger.info({ user: user, orgs: org }, `sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} allowed`);
-    return true;
+    allowed = true;
   } else {
-    logger.info({ user: user, orgs: org }, `sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} forbidden`);
-    return false;
+    allowed = false;
   }
+  logger.info({ user: user, orgs: org }, `sitemapAllowedForUser(): Access to Sitemap/Page ${sitemapname} allowed: ${allowed} (typeof ${typeof allowed})`);
+  return allowed;
 };

--- a/nodejs/src/server.js
+++ b/nodejs/src/server.js
@@ -6,7 +6,7 @@ import pino from 'pino-http';
 import logger from './logger.js';
 import swagger from './components/swagger.js';
 import routes from './components/routes.js';
-import { replaceSpaceHyphenWithUnderscore } from './components/middleware.js';
+import { replaceSpaceHyphenWithUnderscore, formatOrgs } from './components/middleware.js';
 
 dotenv.config();
 
@@ -30,11 +30,25 @@ export const PORT = (argv.port !== undefined) ? argv.port : (process.env.PORT !=
 export const backendInfo = {
   HOST: (argv.host !== undefined) ? argv.host : (process.env.HOST !== undefined) ? process.env.HOST : 'http://127.0.0.1:8080'
 };
+/**
+ * Administrator Organizational Unit. Defaults to admin
+ */
+export const ADMIN_OU = process.env.ADMIN_OU || 'admin';
+logger.debug(logger.debug(`Admin organization unit is ${ADMIN_OU}`));
+
+/**
+ * Separates the organization name at beginning of Sitemap name from the full name.
+ *
+ * @memberof sitemapsSecurity
+ */
+export const ORG_SEPARATOR = process.env.ORG_SEPARATOR || '_org_';
+logger.debug(`Organization separator is ${ORG_SEPARATOR}`);
 const app = express();
 
 // Server setup.
 app.set('trust proxy', 'loopback');
 app.use(replaceSpaceHyphenWithUnderscore(['X-OPENHAB-USER', 'X-OPENHAB-ORG']));
+app.use(formatOrgs());
 app.disable('x-powered-by');
 app.disable('etag');
 app.use(express.json());

--- a/nodejs/src/server.js
+++ b/nodejs/src/server.js
@@ -43,7 +43,7 @@ app.use(pino({
   logger: logger,
   customLogLevel: function (res, err) {
     if (res.statusCode >= 400 && res.statusCode < 500) { // Client error
-      return 'debug';
+      return 'trace';
     } else if (res.statusCode >= 500 || err) { // Server error
       return 'error';
     } else if (res.statusCode >= 300 && res.statusCode < 400) { // Redirections


### PR DESCRIPTION
This PR adds support for the MainUI & fixes multiple Bugs.

Access to the individual pages is authorized the same way as for Sitemaps.

Additionally, an endpoint for admin authorization was added. (It checks whether a client has admin rights, currently no usage case for this endpoint.)